### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-meta-file-check.yml
+++ b/.github/workflows/unity-meta-file-check.yml
@@ -12,6 +12,9 @@ on:
       - src/ObjectReference.Unity/Packages/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   meta-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/ObjectReference/security/code-scanning/2](https://github.com/AndanteTribe/ObjectReference/security/code-scanning/2)

Add an explicit `permissions` block to the workflow YAML so the `GITHUB_TOKEN` is constrained to the minimum required scope.

Best fix (without changing behavior): set workflow-level permissions to read-only repository contents, since this workflow checks code/meta files and does not create issues, comments, releases, or push changes. This should be added near the top-level keys (after `on` or before `jobs`) in `.github/workflows/unity-meta-file-check.yml`:

- `permissions:`
  - `contents: read`

This applies to all jobs in the workflow (including `meta-check`) unless overridden, and directly addresses the CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
